### PR TITLE
Organization api issue

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -93,6 +93,11 @@
 			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/grimni/controller/AuthController.java
+++ b/backend/src/main/java/com/grimni/controller/AuthController.java
@@ -92,19 +92,19 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> loginUser(@RequestBody LoginRequest request) {
-        logger.info("Login attempt for user: {}", request.username());
+        logger.info("Login attempt for user: {}", request.email());
         try {
-            User user = userService.login(request.username(), request.password());
+            User user = userService.login(request.email(), request.password());
             OrgUserBridge bridge = resolveBridge(user, request.orgId());
             String jwtToken = jwtUtil.generateToken(user, bridge);
 
             ResponseCookie refToken = refService.createAndStoreRefreshToken(user);
 
-            logger.info("Login successful for user: {}", request.username());
+            logger.info("Login successful for user: {}", request.email());
             return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, refToken.toString()).body(jwtToken);
 
         } catch(Exception error) {
-            logger.warn("Login failed for user '{}': {}", request.username(), error.getMessage());
+            logger.warn("Login failed for user '{}': {}", request.email(), error.getMessage());
             return ResponseEntity.status(401).body(error.getMessage());
         }
     } 

--- a/backend/src/main/java/com/grimni/controller/MeController.java
+++ b/backend/src/main/java/com/grimni/controller/MeController.java
@@ -1,0 +1,41 @@
+package com.grimni.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.grimni.dto.OrganizationResponse;
+import com.grimni.security.JwtUserPrinciple;
+import com.grimni.service.OrganizationService;
+
+@RestController
+@RequestMapping("/me")
+public class MeController {
+
+    private final OrganizationService organizationService;
+
+    public MeController(OrganizationService organizationService) {
+        this.organizationService = organizationService;
+    }
+
+    @GetMapping("/organizations")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getMyOrganizations(Authentication authentication) {
+        try {
+            JwtUserPrinciple principal = (JwtUserPrinciple) authentication.getPrincipal();
+            List<OrganizationResponse> orgs = organizationService.findOrganizationsByUserId(principal.userId())
+                    .stream()
+                    .map(OrganizationResponse::fromEntity)
+                    .toList();
+            return ResponseEntity.ok(orgs);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/grimni/controller/OrganizationController.java
+++ b/backend/src/main/java/com/grimni/controller/OrganizationController.java
@@ -1,8 +1,73 @@
 package com.grimni.controller;
 
-import org.springframework.stereotype.Controller;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+import com.grimni.dto.CreateOrganizationRequest;
+import com.grimni.dto.OrganizationResponse;
+import com.grimni.dto.UpdateOrganizationRequest;
+import com.grimni.domain.Organization;
+import com.grimni.security.JwtUserPrinciple;
+import com.grimni.service.OrganizationService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/organizations")
 public class OrganizationController {
-    
+
+    private final OrganizationService organizationService;
+
+    public OrganizationController(OrganizationService organizationService) {
+        this.organizationService = organizationService;
+    }
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> createOrganization(
+        @Valid @RequestBody CreateOrganizationRequest request, 
+        Authentication authentication) {
+        try {
+            JwtUserPrinciple principal = (JwtUserPrinciple) authentication.getPrincipal();
+            Organization org = organizationService.createOrganization(request, principal.userId());
+            return ResponseEntity.status(HttpStatus.CREATED).body(OrganizationResponse.fromEntity(org));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/{orgId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<?> getOrganization(@PathVariable Long orgId, Authentication authentication) {
+        try {
+            JwtUserPrinciple principle = (JwtUserPrinciple) authentication.getPrincipal();
+            Organization org = organizationService.findOrganizationByIdAndUser(orgId, principle.userId());
+            return ResponseEntity.ok(OrganizationResponse.fromEntity(org));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+        }
+    }
+
+    @PatchMapping("/{orgId}")
+    @PreAuthorize("hasAnyAuthority('OWNER', 'MANAGER')")
+    public ResponseEntity<?> updateOrganization(@PathVariable Long orgId,
+                                                @Valid @RequestBody UpdateOrganizationRequest request,
+                                                Authentication authentication) {
+        try {
+            JwtUserPrinciple principal = (JwtUserPrinciple) authentication.getPrincipal();
+            Organization org = organizationService.updateOrganization(orgId, request, principal.userId());
+            return ResponseEntity.ok(OrganizationResponse.fromEntity(org));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+        }
+    }
 }

--- a/backend/src/main/java/com/grimni/controller/OrganizationController.java
+++ b/backend/src/main/java/com/grimni/controller/OrganizationController.java
@@ -1,0 +1,8 @@
+package com.grimni.controller;
+
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class OrganizationController {
+    
+}

--- a/backend/src/main/java/com/grimni/domain/ids/CcpUserBridgeId.java
+++ b/backend/src/main/java/com/grimni/domain/ids/CcpUserBridgeId.java
@@ -11,6 +11,7 @@ public class CcpUserBridgeId implements Serializable {
     private Long ccpId;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "user_role")
     private RoutineUserRole userRole;
 
     public CcpUserBridgeId() {}

--- a/backend/src/main/java/com/grimni/dto/CreateOrganizationRequest.java
+++ b/backend/src/main/java/com/grimni/dto/CreateOrganizationRequest.java
@@ -1,0 +1,20 @@
+package com.grimni.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreateOrganizationRequest(
+    @NotBlank(message = "Organization name cannot be blank")
+    String orgName,
+
+    String orgAddress,
+
+    @NotNull(message = "Organization number is required")
+    @Positive(message = "Organization number must be positive")
+    int orgNumber,
+
+    
+    boolean alcoholEnabled,
+    boolean foodEnabled
+) {}

--- a/backend/src/main/java/com/grimni/dto/LoginRequest.java
+++ b/backend/src/main/java/com/grimni/dto/LoginRequest.java
@@ -1,5 +1,5 @@
 package com.grimni.dto;
 
-public record LoginRequest(String username, String password, Long orgId) {
+public record LoginRequest(String email, String password, Long orgId) {
     
 }

--- a/backend/src/main/java/com/grimni/dto/OrganizationRequest.java
+++ b/backend/src/main/java/com/grimni/dto/OrganizationRequest.java
@@ -1,5 +1,0 @@
-package com.grimni.dto;
-
-public record OrganizationRequest(String orgName, Long orgId) {
-    
-}

--- a/backend/src/main/java/com/grimni/dto/OrganizationRequest.java
+++ b/backend/src/main/java/com/grimni/dto/OrganizationRequest.java
@@ -1,0 +1,5 @@
+package com.grimni.dto;
+
+public record OrganizationRequest(String orgName, Long orgId) {
+    
+}

--- a/backend/src/main/java/com/grimni/dto/OrganizationResponse.java
+++ b/backend/src/main/java/com/grimni/dto/OrganizationResponse.java
@@ -1,0 +1,23 @@
+package com.grimni.dto;
+
+import com.grimni.domain.Organization;
+
+public record OrganizationResponse(
+    Long id,
+    String orgName,
+    String orgAddress,
+    int orgNumber,
+    boolean alcoholEnabled,
+    boolean foodEnabled
+) {
+    public static OrganizationResponse fromEntity(Organization org) {
+        return new OrganizationResponse(
+            org.getId(),
+            org.getOrgName(),
+            org.getOrgAddress(),
+            org.getOrgNumber(),
+            org.getAlcoholEnabled(),
+            org.getFoodEnabled()
+        );
+    }
+}

--- a/backend/src/main/java/com/grimni/dto/UpdateOrganizationRequest.java
+++ b/backend/src/main/java/com/grimni/dto/UpdateOrganizationRequest.java
@@ -1,0 +1,18 @@
+package com.grimni.dto;
+
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record UpdateOrganizationRequest(
+    @Size(min = 1, message = "Organization name cannot be empty")
+    String orgName,
+
+    String orgAddress,
+
+    @Positive(message = "Organization number must be positive")
+    Integer orgNumber,
+
+    Boolean alcoholEnabled,
+
+    Boolean foodEnabled
+) {}

--- a/backend/src/main/java/com/grimni/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/grimni/exception/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package com.grimni.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationErrors(
+            MethodArgumentNotValidException ex) {
+
+        Map<String, String> errors = new HashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+            errors.put(error.getField(), error.getDefaultMessage())
+        );
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+}
+    
+

--- a/backend/src/main/java/com/grimni/repository/OrgUserBridgeRepository.java
+++ b/backend/src/main/java/com/grimni/repository/OrgUserBridgeRepository.java
@@ -1,10 +1,14 @@
 package com.grimni.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.grimni.domain.OrgUserBridge;
 import com.grimni.domain.ids.OrgUserBridgeId;
 
 public interface OrgUserBridgeRepository extends JpaRepository<OrgUserBridge, OrgUserBridgeId> {
-
+    List<OrgUserBridge> findByUserId(Long userId);
+    Optional<OrgUserBridge> findByOrganizationIdAndUserId(Long orgId, Long userId);
 }

--- a/backend/src/main/java/com/grimni/security/JwtUserPrinciple.java
+++ b/backend/src/main/java/com/grimni/security/JwtUserPrinciple.java
@@ -1,0 +1,17 @@
+package com.grimni.security;
+
+import java.io.Serializable;
+
+import org.springframework.security.core.AuthenticatedPrincipal;
+
+public record JwtUserPrinciple(
+        Long userId,
+        Long orgId,
+        String username,
+        String role) implements AuthenticatedPrincipal, Serializable {
+
+        @Override
+        public String getName() {
+            return username;
+        }
+}

--- a/backend/src/main/java/com/grimni/security/SecurityConfig.java
+++ b/backend/src/main/java/com/grimni/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -15,6 +16,7 @@ import com.grimni.util.JwtAuthFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
     private final JwtAuthFilter jwtAuthFilter;
 
@@ -32,9 +34,6 @@ public class SecurityConfig {
         // expose endpoint /auth/login - /auth/register - /auth/refresh - /health, as available to all, but any other requests to other endpoints require authentication
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/auth/login", "/auth/register", "/auth/refresh", "/health").permitAll() // for this url endpoint, all requests are permitted
-                .requestMatchers("/admin/**").hasAuthority("ADMIN") // allow /admin endpoints for users with role admin
-                .requestMatchers("/manager/**").hasAuthority("MANAGER")
-                .requestMatchers("/employee/**").hasAuthority("EMPLOYEE")
                 .anyRequest().authenticated()); // to any other requests to endpoints, authentication is needed
 
         // since SecurityConfig is initially run before Server Dispatchlet, it blocks due to CORS restriction, therefore we have

--- a/backend/src/main/java/com/grimni/service/OrganizationService.java
+++ b/backend/src/main/java/com/grimni/service/OrganizationService.java
@@ -1,5 +1,88 @@
 package com.grimni.service;
 
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.grimni.domain.OrgUserBridge;
+import com.grimni.domain.Organization;
+import com.grimni.domain.User;
+import com.grimni.domain.enums.OrgUserRole;
+import com.grimni.domain.ids.OrgUserBridgeId;
+import com.grimni.dto.CreateOrganizationRequest;
+import com.grimni.dto.UpdateOrganizationRequest;
+import com.grimni.repository.OrgUserBridgeRepository;
+import com.grimni.repository.OrganizationRepository;
+import com.grimni.repository.UserRepository;
+
+@Service
 public class OrganizationService {
-    
+
+    private final OrganizationRepository organizationRepository;
+    private final OrgUserBridgeRepository orgUserBridgeRepository;
+    private final UserRepository userRepository;
+
+    public OrganizationService(OrganizationRepository organizationRepository,
+                               OrgUserBridgeRepository orgUserBridgeRepository,
+                               UserRepository userRepository) {
+        this.organizationRepository = organizationRepository;
+        this.orgUserBridgeRepository = orgUserBridgeRepository;
+        this.userRepository = userRepository;
+    }
+
+    public Organization createOrganization(CreateOrganizationRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Organization org = new Organization();
+        org.setOrgName(request.orgName());
+        org.setOrgAddress(request.orgAddress());
+        org.setOrgNumber(request.orgNumber());
+        org.setAlcoholEnabled(request.alcoholEnabled());
+        org.setFoodEnabled(request.foodEnabled());
+
+        org = organizationRepository.save(org);
+
+        OrgUserBridge bridge = new OrgUserBridge();
+        bridge.setId(new OrgUserBridgeId(org.getId(), userId));
+        bridge.setOrganization(org);
+        bridge.setUser(user);
+        bridge.setUserRole(OrgUserRole.OWNER);
+        orgUserBridgeRepository.save(bridge);
+
+        return org;
+    }
+
+    public List<Organization> findOrganizationsByUserId(Long userId) {
+        return orgUserBridgeRepository.findByUserId(userId).stream()
+                .map(OrgUserBridge::getOrganization)
+                .toList();
+    }
+
+    public Organization findOrganizationByIdAndUser(Long orgId, Long userId) {
+        OrgUserBridge bridge = orgUserBridgeRepository.findByOrganizationIdAndUserId(orgId, userId)
+                .orElseThrow(() -> new RuntimeException("Organization not found"));
+        return bridge.getOrganization();
+    }
+
+    public Organization findOrganizationById(Long orgId) {
+        return organizationRepository.findById(orgId)
+                .orElseThrow(() -> new RuntimeException("Organization not found"));
+    }
+
+    public Organization updateOrganization(Long orgId, UpdateOrganizationRequest request, Long userId) {
+        orgUserBridgeRepository.findByOrganizationIdAndUserId(orgId, userId)
+                .orElseThrow(() -> new RuntimeException("Organization not found"));
+
+        Organization org = organizationRepository.findById(orgId)
+                .orElseThrow(() -> new RuntimeException("Organization not found"));
+
+        if (request.orgName() != null) org.setOrgName(request.orgName());
+        if (request.orgAddress() != null) org.setOrgAddress(request.orgAddress());
+        if (request.orgNumber() != null) org.setOrgNumber(request.orgNumber());
+        if (request.alcoholEnabled() != null) org.setAlcoholEnabled(request.alcoholEnabled());
+        if (request.foodEnabled() != null) org.setFoodEnabled(request.foodEnabled());
+
+        return organizationRepository.save(org);
+    }
 }

--- a/backend/src/main/java/com/grimni/service/UserService.java
+++ b/backend/src/main/java/com/grimni/service/UserService.java
@@ -39,20 +39,20 @@ public class UserService {
         return saved;
     }
 
-    public User login(String username, String password) {
-        logger.info("Login attempt for user: {}", username);
-        User user = userRepository.findByUsername(username)
+    public User login(String email, String password) {
+        logger.info("Login attempt for email: {}", email);
+        User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> {
-                    logger.warn("Login failed: user '{}' not found", username);
+                    logger.warn("Login failed: email '{}' not found", email);
                     return new IllegalArgumentException("User not found");
                 });
 
         if (!passwordEncoder.matches(password, user.getPasswordHash())) {
-            logger.warn("Login failed: invalid password for user '{}'", username);
+            logger.warn("Login failed: invalid password for email '{}'", email);
             throw new IllegalArgumentException("Invalid password");
         }
 
-        logger.info("User '{}' logged in successfully", username);
+        logger.info("User '{}' logged in successfully", user.getUsername());
         return user;
     }
 

--- a/backend/src/main/java/com/grimni/util/JwtAuthFilter.java
+++ b/backend/src/main/java/com/grimni/util/JwtAuthFilter.java
@@ -7,6 +7,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.grimni.security.JwtUserPrinciple;
+
 import org.springframework.lang.NonNull;
 
 import jakarta.servlet.FilterChain;
@@ -42,17 +45,27 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                 return;
             }
 
-            String userId = jwtUtil.extractUserId(jwtToken);
+            
+            Long userId = jwtUtil.extractUserId(jwtToken);
             String role = jwtUtil.extractUserRole(jwtToken);
+            String username = jwtUtil.extractUsername(jwtToken);
+            Long orgId = jwtUtil.extractUserOrgId(jwtToken);
 
-            if (userId == null || role == null) {
+            if (userId == null || role == null || username == null || orgId == null) {
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                logger.error("Could not extract user ID or role from token");
+                logger.error("Missing required claims in JWT token");
                 return;
             }
-            
+
+            JwtUserPrinciple principle = new JwtUserPrinciple(
+                userId,
+                orgId,
+                username,
+                role
+            );
+
             // Class in spring security that represents an authentication object (in this case user)
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userId, null, List.of(new SimpleGrantedAuthority(role))/* SimpleGrantedAuth wraps the role string so that it can be subsequently used in SecurityConfig as .hasRole() */);
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(principle, null, List.of(new SimpleGrantedAuthority(role))/* SimpleGrantedAuth wraps the role string so that it can be subsequently used in SecurityConfig as .hasAuthority() */);
             
             // SecurityContextHolder is a global context storage, storing the authenticated entity for use in the filterchain
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/backend/src/main/java/com/grimni/util/JwtUtil.java
+++ b/backend/src/main/java/com/grimni/util/JwtUtil.java
@@ -1,4 +1,6 @@
 package com.grimni.util;
+
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
@@ -15,160 +17,82 @@ import org.springframework.stereotype.Component;
 import com.grimni.domain.OrgUserBridge;
 import com.grimni.domain.User;
 
-
 @Component
 public class JwtUtil {
+
     private static final Logger logger = LoggerFactory.getLogger(JwtUtil.class);
     private SecretKey key;
 
     @Value("${jwt.secret}")
     private String secret;
 
-    /**
-     * Decodes the base64-encoded secret from application properties and constructs
-     * an HMAC-SHA key suitable for signing and verifying JWT tokens.
-     *
-     * @return a {@link SecretKey} derived from the configured JWT secret
-     */
     private SecretKey getKey() {
-        byte[] keyBytes = Decoders.BASE64.decode(secret); // decodes the base64 encoded secret key to an array of raw bytes
-        return Keys.hmacShaKeyFor(keyBytes); // wraps into a SecretKey object for type correspondance with JJWT API
+        byte[] keyBytes = Decoders.BASE64.decode(secret);
+        return Keys.hmacShaKeyFor(keyBytes);
     }
 
-    @PostConstruct // tells spring to call this injection after all other are finished when creating JwtUtil bean
+    @PostConstruct
     private void init() {
         this.key = getKey();
     }
 
-
-
-    /**
-     * Generates a signed JWT token with the given username as subject, valid for 5 minutes.
-     * @param username the subject to embed in the token
-     * @return a signed JWT string
-     */
-
     public String generateToken(User user, OrgUserBridge bridge) {
-        Date expiration= new Date(System.currentTimeMillis() + 15 * 60 * 1000); // 15 minute token expiry limit
-        
+        Date expiration = new Date(System.currentTimeMillis() + 15 * 60 * 1000);
+
         try {
             String jwt = Jwts.builder()
-            .subject(user.getId().toString())
-            .claim("username", user.getUsername())
-            .claim("role", bridge.getUserRole().name())
-            .claim("orgId", bridge.getOrganization().getId())
-            .issuedAt(new Date())
-            .expiration(expiration)
-            .signWith(key)
-            .compact();
-            
-            logger.info("Succesfully generated jwt token");
+                .subject(user.getId().toString())
+                .claim("username", user.getUsername())
+                .claim("role", bridge.getUserRole().name())
+                .claim("orgId", bridge.getOrganization().getId())
+                .issuedAt(new Date())
+                .expiration(expiration)
+                .signWith(key)
+                .compact();
 
+            logger.info("Successfully generated JWT token");
             return jwt;
-        } catch(JwtException error) {
-            logger.error("error creating jwt: " + error);
+        } catch (JwtException error) {
+            logger.error("Error creating JWT: {}", error.getMessage());
             return null;
         }
     }
 
-    
     public boolean isTokenValid(String jwtToken) {
         try {
-            
             if (jwtToken == null || jwtToken.isEmpty()) {
-                logger.error("Error: JWT token is null or empty");
+                logger.error("JWT token is null or empty");
                 return false;
             }
-
-            // if parsed token doesn't throw any exception when validating with secretKey, return true
-            Jwts.parser().verifyWith(key).build().parseSignedClaims(jwtToken);
-            logger.info("jwtToken is valid");
+            extractAllClaims(jwtToken);
             return true;
-        } catch(JwtException e) {
-            logger.error("ERROR: jwtToken is not valid");
-            return false; // otherwise false
+        } catch (JwtException e) {
+            logger.error("Invalid JWT token: {}", e.getMessage());
+            return false;
         }
     }
 
-    
-    public String extractUserId(String jwtToken) {
-        try {
-            if (jwtToken == null || jwtToken.isEmpty()) {
-                logger.error("Error: JWT token is null or empty");
-                return null;
-            }
-
-            return Jwts.parser()
+    public Claims extractAllClaims(String jwtToken) {
+        return Jwts.parser()
             .verifyWith(key)
             .build()
             .parseSignedClaims(jwtToken)
-            .getPayload()
-            .getSubject();
-
-        } catch (JwtException error) {
-            logger.error("Error parsing and extracting user id: " + error);
-            return null;
-        }
+            .getPayload();
     }
 
+    public Long extractUserId(String jwtToken) {
+        return Long.parseLong(extractAllClaims(jwtToken).getSubject());
+    }
 
     public String extractUsername(String jwtToken) {
-        try {
-            if (jwtToken == null || jwtToken.isEmpty()) {
-                logger.error("Error: JWT token is null or empty");
-                return null;
-            }
-
-            return Jwts.parser()
-            .verifyWith(key)
-            .build()
-            .parseSignedClaims(jwtToken)
-            .getPayload()
-            .get("username", String.class);
-
-        } catch (JwtException error) {
-            logger.error("Error parsing and extracting username: " + error);
-            return null;
-        }
+        return extractAllClaims(jwtToken).get("username", String.class);
     }
 
     public String extractUserRole(String jwtToken) {
-        try {
-            if (jwtToken == null || jwtToken.isEmpty()) {
-                logger.error("Error: JWT token is null or empty");
-                return null;
-            }
-
-            return Jwts.parser()
-            .verifyWith(key)
-            .build()
-            .parseSignedClaims(jwtToken)
-            .getPayload()
-            .get("role", String.class);
-
-        } catch (JwtException error) {
-            logger.error("Error parsing and extracting user role: " + error);
-            return null;
-        }
+        return extractAllClaims(jwtToken).get("role", String.class);
     }
 
     public Long extractUserOrgId(String jwtToken) {
-        try {
-            if (jwtToken == null || jwtToken.isEmpty()) {
-                logger.error("Error: JWT token is null or empty");
-                return null;
-            }
-
-            return Jwts.parser()
-            .verifyWith(key)
-            .build()
-            .parseSignedClaims(jwtToken)
-            .getPayload()
-            .get("orgId", Long.class);
-
-        } catch (JwtException error) {
-            logger.error("Error parsing and extracting organization ID: " + error);
-            return null;
-        }
+        return extractAllClaims(jwtToken).get("orgId", Long.class);
     }
 }

--- a/backend/src/test/java/com/grimni/backend/controller/OrganizationControllerTest.java
+++ b/backend/src/test/java/com/grimni/backend/controller/OrganizationControllerTest.java
@@ -1,0 +1,478 @@
+package com.grimni.backend.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grimni.controller.OrganizationController;
+import com.grimni.controller.MeController;
+import com.grimni.domain.Organization;
+import com.grimni.dto.CreateOrganizationRequest;
+import com.grimni.dto.UpdateOrganizationRequest;
+import com.grimni.security.JwtUserPrinciple;
+import com.grimni.service.OrganizationService;
+import org.springframework.context.annotation.Import;
+import com.grimni.security.SecurityConfig;
+import com.grimni.util.JwtUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.grimni.util.JwtAuthFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest({OrganizationController.class, MeController.class})
+@Import(SecurityConfig.class)
+public class OrganizationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OrganizationService organizationService;
+
+    @MockitoBean
+    private JwtUtil jwtUtil;
+
+    @MockitoBean
+    private JwtAuthFilter jwtAuthFilter;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        doAnswer(invocation -> {
+            HttpServletRequest req = invocation.getArgument(0);
+            HttpServletResponse res = invocation.getArgument(1);
+            FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(req, res);
+            return null;
+        }).when(jwtAuthFilter).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class), any(FilterChain.class));
+    }
+
+    private static UsernamePasswordAuthenticationToken authWithRole(String role) {
+        JwtUserPrinciple principal = new JwtUserPrinciple(1L, 10L, "alice", role);
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, List.of(new SimpleGrantedAuthority(role)));
+    }
+
+    private static UsernamePasswordAuthenticationToken authWithRole(String role, Long userId, Long orgId) {
+        JwtUserPrinciple principal = new JwtUserPrinciple(userId, orgId, "alice", role);
+        return new UsernamePasswordAuthenticationToken(
+                principal, null, List.of(new SimpleGrantedAuthority(role)));
+    }
+
+    private Organization createOrg(Long id, String name) {
+        Organization org = new Organization();
+        ReflectionTestUtils.setField(org, "id", id);
+        org.setOrgName(name);
+        org.setOrgAddress("123 Main St");
+        org.setOrgNumber(100);
+        org.setAlcoholEnabled(false);
+        org.setFoodEnabled(true);
+        return org;
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /organizations — success
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("POST /organizations — success")
+    class CreateOrganizationSuccessTests {
+
+        @Test
+        @DisplayName("returns HTTP 201 and the created organization response")
+        void createOrganization_success() throws Exception {
+            Organization org = createOrg(1L, "New Org");
+            CreateOrganizationRequest request = new CreateOrganizationRequest("New Org", "123 Main St", 100, false, true);
+
+            when(organizationService.createOrganization(any(CreateOrganizationRequest.class), eq(1L))).thenReturn(org);
+
+            mockMvc.perform(post("/organizations")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(authentication(authWithRole("OWNER")))
+                            .with(csrf()))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.id").value(1))
+                    .andExpect(jsonPath("$.orgName").value("New Org"))
+                    .andExpect(jsonPath("$.orgAddress").value("123 Main St"))
+                    .andExpect(jsonPath("$.orgNumber").value(100))
+                    .andExpect(jsonPath("$.alcoholEnabled").value(false))
+                    .andExpect(jsonPath("$.foodEnabled").value(true));
+
+            verify(organizationService).createOrganization(any(CreateOrganizationRequest.class), eq(1L));
+        }
+
+        @Test
+        @DisplayName("any authenticated user can create an organization")
+        void createOrganization_workerCanCreate() throws Exception {
+            Organization org = createOrg(2L, "Worker Org");
+            CreateOrganizationRequest request = new CreateOrganizationRequest("Worker Org", "456 St", 200, true, false);
+
+            when(organizationService.createOrganization(any(CreateOrganizationRequest.class), eq(1L))).thenReturn(org);
+
+            mockMvc.perform(post("/organizations")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(authentication(authWithRole("WORKER")))
+                            .with(csrf()))
+                    .andExpect(status().isCreated());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /organizations — failure
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("POST /organizations — failure")
+    class CreateOrganizationFailureTests {
+
+        @Test
+        @DisplayName("returns HTTP 400 when user not found")
+        void createOrganization_userNotFound_returns400() throws Exception {
+            CreateOrganizationRequest request = new CreateOrganizationRequest("New Org", "123 Main St", 100, false, true);
+
+            when(organizationService.createOrganization(any(CreateOrganizationRequest.class), eq(1L)))
+                    .thenThrow(new RuntimeException("User not found"));
+
+            mockMvc.perform(post("/organizations")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(authentication(authWithRole("OWNER")))
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string("User not found"));
+        }
+
+        @Test
+        @DisplayName("returns HTTP 403 when unauthenticated")
+        void createOrganization_unauthenticated_returns403() throws Exception {
+            CreateOrganizationRequest request = new CreateOrganizationRequest("New Org", "123 Main St", 100, false, true);
+
+            mockMvc.perform(post("/organizations")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(csrf()))
+                    .andExpect(status().isForbidden());
+
+            verify(organizationService, never()).createOrganization(any(), any());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /me/organizations — success
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("GET /me/organizations — success")
+    class GetMyOrganizationsSuccessTests {
+
+        @Test
+        @DisplayName("returns HTTP 200 and list of organization responses")
+        void getMyOrganizations_success() throws Exception {
+            Organization org1 = createOrg(1L, "Org A");
+            Organization org2 = createOrg(2L, "Org B");
+
+            when(organizationService.findOrganizationsByUserId(1L)).thenReturn(List.of(org1, org2));
+
+            mockMvc.perform(get("/me/organizations")
+                            .with(authentication(authWithRole("WORKER"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$[0].id").value(1))
+                    .andExpect(jsonPath("$[0].orgName").value("Org A"))
+                    .andExpect(jsonPath("$[1].id").value(2))
+                    .andExpect(jsonPath("$[1].orgName").value("Org B"));
+        }
+
+        @Test
+        @DisplayName("returns HTTP 200 and empty list when user has no organizations")
+        void getMyOrganizations_empty() throws Exception {
+            when(organizationService.findOrganizationsByUserId(1L)).thenReturn(List.of());
+
+            mockMvc.perform(get("/me/organizations")
+                            .with(authentication(authWithRole("WORKER"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isEmpty());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /me/organizations — failure
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("GET /me/organizations — failure")
+    class GetMyOrganizationsFailureTests {
+
+        @Test
+        @DisplayName("returns HTTP 500 when service throws")
+        void getMyOrganizations_serviceThrows_returns500() throws Exception {
+            when(organizationService.findOrganizationsByUserId(1L))
+                    .thenThrow(new RuntimeException("Database error"));
+
+            mockMvc.perform(get("/me/organizations")
+                            .with(authentication(authWithRole("WORKER"))))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(content().string("Database error"));
+        }
+
+        @Test
+        @DisplayName("returns HTTP 403 when unauthenticated")
+        void getMyOrganizations_unauthenticated_returns403() throws Exception {
+            mockMvc.perform(get("/me/organizations"))
+                    .andExpect(status().isForbidden());
+
+            verify(organizationService, never()).findOrganizationsByUserId(any());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /organizations/{orgId} — success
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("GET /organizations/{orgId} — success")
+    class GetOrganizationSuccessTests {
+
+        @Test
+        @DisplayName("returns HTTP 200 and the organization response")
+        void getOrganization_success() throws Exception {
+            Organization org = createOrg(1L, "Test Org");
+
+            when(organizationService.findOrganizationByIdAndUser(1L, 1L)).thenReturn(org);
+
+            mockMvc.perform(get("/organizations/1")
+                            .with(authentication(authWithRole("WORKER"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1))
+                    .andExpect(jsonPath("$.orgName").value("Test Org"))
+                    .andExpect(jsonPath("$.orgNumber").value(100))
+                    .andExpect(jsonPath("$.orgAddress").value("123 Main St"))
+                    .andExpect(jsonPath("$.alcoholEnabled").value(false))
+                    .andExpect(jsonPath("$.foodEnabled").value(true));
+        }
+
+        @Test
+        @DisplayName("response does not contain entity collections")
+        void getOrganization_responseHasNoCollections() throws Exception {
+            Organization org = createOrg(1L, "Test Org");
+
+            when(organizationService.findOrganizationByIdAndUser(1L, 1L)).thenReturn(org);
+
+            mockMvc.perform(get("/organizations/1")
+                            .with(authentication(authWithRole("WORKER"))))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.todos").doesNotExist())
+                    .andExpect(jsonPath("$.members").doesNotExist())
+                    .andExpect(jsonPath("$.ccps").doesNotExist())
+                    .andExpect(jsonPath("$.deviations").doesNotExist());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /organizations/{orgId} — failure
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("GET /organizations/{orgId} — failure")
+    class GetOrganizationFailureTests {
+
+        @Test
+        @DisplayName("returns HTTP 404 when organization not found")
+        void getOrganization_notFound_returns404() throws Exception {
+            when(organizationService.findOrganizationByIdAndUser(999L, 1L))
+                    .thenThrow(new RuntimeException("Organization not found"));
+
+            mockMvc.perform(get("/organizations/999")
+                            .with(authentication(authWithRole("WORKER"))))
+                    .andExpect(status().isNotFound())
+                    .andExpect(content().string("Organization not found"));
+        }
+
+        @Test
+        @DisplayName("returns HTTP 404 when user does not belong to organization")
+        void getOrganization_notMember_returns404() throws Exception {
+            when(organizationService.findOrganizationByIdAndUser(99L, 1L))
+                    .thenThrow(new RuntimeException("Organization not found"));
+
+            mockMvc.perform(get("/organizations/99")
+                            .with(authentication(authWithRole("WORKER"))))
+                    .andExpect(status().isNotFound())
+                    .andExpect(content().string("Organization not found"));
+
+            verify(organizationService).findOrganizationByIdAndUser(99L, 1L);
+        }
+
+        @Test
+        @DisplayName("returns HTTP 403 when unauthenticated")
+        void getOrganization_unauthenticated_returns403() throws Exception {
+            mockMvc.perform(get("/organizations/1"))
+                    .andExpect(status().isForbidden());
+
+            verify(organizationService, never()).findOrganizationByIdAndUser(any(), any());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // PATCH /organizations/{orgId} — success
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("PATCH /organizations/{orgId} — success")
+    class UpdateOrganizationSuccessTests {
+
+        @Test
+        @DisplayName("returns HTTP 200 and the updated organization response")
+        void updateOrganization_success() throws Exception {
+            Organization updated = createOrg(1L, "Updated Org");
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("Updated Org", null, null, null, null);
+
+            when(organizationService.updateOrganization(eq(1L), any(UpdateOrganizationRequest.class), eq(1L)))
+                    .thenReturn(updated);
+
+            mockMvc.perform(patch("/organizations/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(authentication(authWithRole("OWNER")))
+                            .with(csrf()))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(1))
+                    .andExpect(jsonPath("$.orgName").value("Updated Org"))
+                    .andExpect(jsonPath("$.orgAddress").value("123 Main St"))
+                    .andExpect(jsonPath("$.orgNumber").value(100));
+
+            verify(organizationService).updateOrganization(eq(1L), any(UpdateOrganizationRequest.class), eq(1L));
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // PATCH /organizations/{orgId} — failure
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("PATCH /organizations/{orgId} — failure")
+    class UpdateOrganizationFailureTests {
+
+        @Test
+        @DisplayName("returns HTTP 400 when organization not found")
+        void updateOrganization_notFound_returns400() throws Exception {
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("Name", "Addr", 100, false, false);
+
+            when(organizationService.updateOrganization(eq(999L), any(UpdateOrganizationRequest.class), eq(1L)))
+                    .thenThrow(new RuntimeException("Organization not found"));
+
+            mockMvc.perform(patch("/organizations/999")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(authentication(authWithRole("OWNER")))
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string("Organization not found"));
+        }
+
+        @Test
+        @DisplayName("returns HTTP 400 when user does not belong to organization")
+        void updateOrganization_notMember_returns400() throws Exception {
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("Name", null, null, null, null);
+
+            when(organizationService.updateOrganization(eq(99L), any(UpdateOrganizationRequest.class), eq(1L)))
+                    .thenThrow(new RuntimeException("Organization not found"));
+
+            mockMvc.perform(patch("/organizations/99")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(authentication(authWithRole("OWNER")))
+                            .with(csrf()))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(content().string("Organization not found"));
+
+            verify(organizationService).updateOrganization(eq(99L), any(UpdateOrganizationRequest.class), eq(1L));
+        }
+    }
+
+    // =========================================================================
+    // AUTHORIZATION TESTS — @PreAuthorize enforcement
+    // =========================================================================
+    @Nested
+    @DisplayName("Authorization — @PreAuthorize enforcement")
+    class AuthorizationTests {
+
+        @Test
+        @DisplayName("PATCH — WORKER role is rejected with 403")
+        void updateOrganization_workerRole_returns403() throws Exception {
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("Name", "Addr", 100, false, false);
+
+            mockMvc.perform(patch("/organizations/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(authentication(authWithRole("WORKER")))
+                            .with(csrf()))
+                    .andExpect(status().isForbidden());
+
+            verify(organizationService, never()).updateOrganization(any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("PATCH — OWNER role is allowed")
+        void updateOrganization_ownerRole_isAllowed() throws Exception {
+            Organization updated = createOrg(1L, "Updated");
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("Updated", null, null, null, null);
+
+            when(organizationService.updateOrganization(eq(1L), any(UpdateOrganizationRequest.class), eq(1L)))
+                    .thenReturn(updated);
+
+            mockMvc.perform(patch("/organizations/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(authentication(authWithRole("OWNER")))
+                            .with(csrf()))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("PATCH — MANAGER role is allowed")
+        void updateOrganization_managerRole_isAllowed() throws Exception {
+            Organization updated = createOrg(1L, "Updated");
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("Updated", null, null, null, null);
+
+            when(organizationService.updateOrganization(eq(1L), any(UpdateOrganizationRequest.class), eq(1L)))
+                    .thenReturn(updated);
+
+            mockMvc.perform(patch("/organizations/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(authentication(authWithRole("MANAGER")))
+                            .with(csrf()))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("PATCH — unauthenticated request is rejected with 403")
+        void updateOrganization_unauthenticated_returns403() throws Exception {
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("Name", "Addr", 100, false, false);
+
+            mockMvc.perform(patch("/organizations/1")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+                            .with(csrf()))
+                    .andExpect(status().isForbidden());
+
+            verify(organizationService, never()).updateOrganization(any(), any(), any());
+        }
+    }
+}

--- a/backend/src/test/java/com/grimni/backend/service/OrganizationServiceTest.java
+++ b/backend/src/test/java/com/grimni/backend/service/OrganizationServiceTest.java
@@ -1,0 +1,269 @@
+package com.grimni.backend.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.grimni.domain.OrgUserBridge;
+import com.grimni.domain.Organization;
+import com.grimni.domain.User;
+import com.grimni.domain.enums.OrgUserRole;
+import com.grimni.dto.CreateOrganizationRequest;
+import com.grimni.dto.UpdateOrganizationRequest;
+import com.grimni.repository.OrgUserBridgeRepository;
+import com.grimni.repository.OrganizationRepository;
+import com.grimni.repository.UserRepository;
+import com.grimni.service.OrganizationService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class OrganizationServiceTest {
+
+    @Mock
+    private OrganizationRepository organizationRepository;
+
+    @Mock
+    private OrgUserBridgeRepository orgUserBridgeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private OrganizationService organizationService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testUser.setUsername("alice");
+        testUser.setEmail("alice@test.com");
+        ReflectionTestUtils.setField(testUser, "id", 1L);
+    }
+
+    private Organization createOrg(Long id, String name) {
+        Organization org = new Organization();
+        ReflectionTestUtils.setField(org, "id", id);
+        org.setOrgName(name);
+        org.setOrgAddress("123 Main St");
+        org.setOrgNumber(100);
+        org.setAlcoholEnabled(false);
+        org.setFoodEnabled(true);
+        return org;
+    }
+
+    // -------------------------------------------------------------------------
+    // createOrganization
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("createOrganization")
+    class CreateOrganizationTests {
+
+        @Test
+        @DisplayName("creates organization and assigns OWNER role to user")
+        void createOrganization_success() {
+            CreateOrganizationRequest request = new CreateOrganizationRequest("Test Org", "123 Main St", 100, true, false);
+
+            when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
+            when(organizationRepository.save(any(Organization.class))).thenAnswer(inv -> {
+                Organization org = inv.getArgument(0);
+                ReflectionTestUtils.setField(org, "id", 10L);
+                return org;
+            });
+            when(orgUserBridgeRepository.save(any(OrgUserBridge.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            Organization result = organizationService.createOrganization(request, 1L);
+
+            assertNotNull(result);
+            assertEquals("Test Org", result.getOrgName());
+            assertEquals("123 Main St", result.getOrgAddress());
+            assertEquals(100, result.getOrgNumber());
+            assertTrue(result.getAlcoholEnabled());
+            assertFalse(result.getFoodEnabled());
+
+            ArgumentCaptor<OrgUserBridge> bridgeCaptor = ArgumentCaptor.forClass(OrgUserBridge.class);
+            verify(orgUserBridgeRepository).save(bridgeCaptor.capture());
+            OrgUserBridge savedBridge = bridgeCaptor.getValue();
+            assertEquals(OrgUserRole.OWNER, savedBridge.getUserRole());
+            assertEquals(testUser, savedBridge.getUser());
+        }
+
+        
+        @Test
+        @DisplayName("throws RuntimeException when user not found")
+        void createOrganization_userNotFound_throws() {
+            CreateOrganizationRequest request = new CreateOrganizationRequest("Test Org", "123 Main St", 100, false, false);
+            when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> organizationService.createOrganization(request, 999L));
+
+            assertEquals("User not found", ex.getMessage());
+            verify(organizationRepository, never()).save(any());
+            verify(orgUserBridgeRepository, never()).save(any());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // findOrganizationsByUserId
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("findOrganizationsByUserId")
+    class FindOrganizationsByUserIdTests {
+
+        @Test
+        @DisplayName("returns list of organizations for user")
+        void findOrganizationsByUserId_success() {
+            Organization org1 = createOrg(1L, "Org A");
+            Organization org2 = createOrg(2L, "Org B");
+
+            OrgUserBridge bridge1 = new OrgUserBridge();
+            bridge1.setOrganization(org1);
+            OrgUserBridge bridge2 = new OrgUserBridge();
+            bridge2.setOrganization(org2);
+
+            when(orgUserBridgeRepository.findByUserId(1L)).thenReturn(List.of(bridge1, bridge2));
+
+            List<Organization> result = organizationService.findOrganizationsByUserId(1L);
+
+            assertEquals(2, result.size());
+            assertEquals("Org A", result.get(0).getOrgName());
+            assertEquals("Org B", result.get(1).getOrgName());
+        }
+
+        @Test
+        @DisplayName("returns empty list when user has no organizations")
+        void findOrganizationsByUserId_noOrgs_returnsEmpty() {
+            when(orgUserBridgeRepository.findByUserId(1L)).thenReturn(List.of());
+
+            List<Organization> result = organizationService.findOrganizationsByUserId(1L);
+
+            assertTrue(result.isEmpty());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // findOrganizationById
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("findOrganizationById")
+    class FindOrganizationByIdTests {
+
+        @Test
+        @DisplayName("returns organization when found")
+        void findOrganizationById_success() {
+            Organization org = createOrg(1L, "Test Org");
+            when(organizationRepository.findById(1L)).thenReturn(Optional.of(org));
+
+            Organization result = organizationService.findOrganizationById(1L);
+
+            assertNotNull(result);
+            assertEquals("Test Org", result.getOrgName());
+        }
+
+        @Test
+        @DisplayName("throws RuntimeException when organization not found")
+        void findOrganizationById_notFound_throws() {
+            when(organizationRepository.findById(999L)).thenReturn(Optional.empty());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> organizationService.findOrganizationById(999L));
+
+            assertEquals("Organization not found", ex.getMessage());
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // updateOrganization
+    // -------------------------------------------------------------------------
+    @Nested
+    @DisplayName("updateOrganization")
+    class UpdateOrganizationTests {
+
+        @Test
+        @DisplayName("updates all fields when provided")
+        void updateOrganization_success() {
+            Organization existing = createOrg(1L, "Old Name");
+            OrgUserBridge bridge = new OrgUserBridge();
+            bridge.setOrganization(existing);
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("New Name", "456 New St", 200, true, true);
+
+            when(orgUserBridgeRepository.findByOrganizationIdAndUserId(1L, 1L)).thenReturn(Optional.of(bridge));
+            when(organizationRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(organizationRepository.save(any(Organization.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            Organization result = organizationService.updateOrganization(1L, request, 1L);
+
+            assertEquals("New Name", result.getOrgName());
+            assertEquals("456 New St", result.getOrgAddress());
+            assertEquals(200, result.getOrgNumber());
+            assertTrue(result.getAlcoholEnabled());
+            assertTrue(result.getFoodEnabled());
+        }
+
+        @Test
+        @DisplayName("only updates non-null fields (partial update)")
+        void updateOrganization_partialUpdate() {
+            Organization existing = createOrg(1L, "Old Name");
+            OrgUserBridge bridge = new OrgUserBridge();
+            bridge.setOrganization(existing);
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("New Name", null, null, null, null);
+
+            when(orgUserBridgeRepository.findByOrganizationIdAndUserId(1L, 1L)).thenReturn(Optional.of(bridge));
+            when(organizationRepository.findById(1L)).thenReturn(Optional.of(existing));
+            when(organizationRepository.save(any(Organization.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            Organization result = organizationService.updateOrganization(1L, request, 1L);
+
+            assertEquals("New Name", result.getOrgName());
+            assertEquals("123 Main St", result.getOrgAddress());
+            assertEquals(100, result.getOrgNumber());
+            assertFalse(result.getAlcoholEnabled());
+            assertTrue(result.getFoodEnabled());
+        }
+
+        @Test
+        @DisplayName("throws when user does not belong to organization")
+        void updateOrganization_notMember_throws() {
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("Name", "Addr", 100, false, false);
+
+            when(orgUserBridgeRepository.findByOrganizationIdAndUserId(1L, 99L)).thenReturn(Optional.empty());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> organizationService.updateOrganization(1L, request, 99L));
+
+            assertEquals("Organization not found", ex.getMessage());
+            verify(organizationRepository, never()).findById(any());
+            verify(organizationRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("throws when organization not found")
+        void updateOrganization_notFound_throws() {
+            OrgUserBridge bridge = new OrgUserBridge();
+            UpdateOrganizationRequest request = new UpdateOrganizationRequest("Name", "Addr", 100, false, false);
+
+            when(orgUserBridgeRepository.findByOrganizationIdAndUserId(999L, 1L)).thenReturn(Optional.of(bridge));
+            when(organizationRepository.findById(999L)).thenReturn(Optional.empty());
+
+            RuntimeException ex = assertThrows(RuntimeException.class,
+                    () -> organizationService.updateOrganization(999L, request, 1L));
+
+            assertEquals("Organization not found", ex.getMessage());
+            verify(organizationRepository, never()).save(any());
+        }
+    }
+}

--- a/backend/src/test/java/com/grimni/backend/util/JwtAuthFilterTest.java
+++ b/backend/src/test/java/com/grimni/backend/util/JwtAuthFilterTest.java
@@ -12,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.grimni.security.JwtUserPrinciple;
 import com.grimni.util.JwtAuthFilter;
 import com.grimni.util.JwtUtil;
 
@@ -33,21 +34,17 @@ public class JwtAuthFilterTest {
 
     @AfterEach
     void tearDown() {
-        // Always clean up SecurityContextHolder between tests to avoid state leaking
         SecurityContextHolder.clearContext();
     }
 
     // -------------------------------------------------------------------------
-    // Filter ordering — verifies JwtAuthFilter runs before UsernamePasswordAuthenticationFilter
+    // Filter ordering
     // -------------------------------------------------------------------------
     @Nested
     class FilterOrderingTest {
 
         @Test
         void jwtAuthFilter_extendsOncePerRequestFilter() {
-            // JwtAuthFilter extends OncePerRequestFilter, which guarantees it executes
-            // exactly once per request, required for a pre-auth filter sitting before
-            // UsernamePasswordAuthenticationFilter in the chain
             assertInstanceOf(OncePerRequestFilter.class, jwtAuthFilter,
                     "JwtAuthFilter must extend OncePerRequestFilter");
         }
@@ -161,6 +158,46 @@ public class JwtAuthFilterTest {
             when(jwtUtil.isTokenValid(any())).thenReturn(true);
             when(jwtUtil.extractUserId(any())).thenReturn(null);
             when(jwtUtil.extractUserRole(any())).thenReturn("MANAGER");
+            when(jwtUtil.extractUsername(any())).thenReturn("alice");
+            when(jwtUtil.extractUserOrgId(any())).thenReturn(1L);
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer some.valid.token");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = mock(FilterChain.class);
+
+            jwtAuthFilter.doFilter(request, response, chain);
+
+            assertEquals(401, response.getStatus());
+            verify(chain, never()).doFilter(any(), any());
+        }
+
+        @Test
+        void validTokenButNullUsername_returns401() throws Exception {
+            when(jwtUtil.isTokenValid(any())).thenReturn(true);
+            when(jwtUtil.extractUserId(any())).thenReturn(1L);
+            when(jwtUtil.extractUserRole(any())).thenReturn("MANAGER");
+            when(jwtUtil.extractUsername(any())).thenReturn(null);
+            when(jwtUtil.extractUserOrgId(any())).thenReturn(1L);
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer some.valid.token");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = mock(FilterChain.class);
+
+            jwtAuthFilter.doFilter(request, response, chain);
+
+            assertEquals(401, response.getStatus());
+            verify(chain, never()).doFilter(any(), any());
+        }
+
+        @Test
+        void validTokenButNullOrgId_returns401() throws Exception {
+            when(jwtUtil.isTokenValid(any())).thenReturn(true);
+            when(jwtUtil.extractUserId(any())).thenReturn(1L);
+            when(jwtUtil.extractUserRole(any())).thenReturn("MANAGER");
+            when(jwtUtil.extractUsername(any())).thenReturn("alice");
+            when(jwtUtil.extractUserOrgId(any())).thenReturn(null);
 
             MockHttpServletRequest request = new MockHttpServletRequest();
             request.addHeader("Authorization", "Bearer some.valid.token");
@@ -180,11 +217,17 @@ public class JwtAuthFilterTest {
     @Nested
     class ValidTokenTest {
 
+        private void stubValidToken() {
+            when(jwtUtil.isTokenValid(any())).thenReturn(true);
+            when(jwtUtil.extractUserId(any())).thenReturn(1L);
+            when(jwtUtil.extractUserRole(any())).thenReturn("MANAGER");
+            when(jwtUtil.extractUsername(any())).thenReturn("alice");
+            when(jwtUtil.extractUserOrgId(any())).thenReturn(7L);
+        }
+
         @Test
         void validToken_returns200() throws Exception {
-            when(jwtUtil.isTokenValid(any())).thenReturn(true);
-            when(jwtUtil.extractUserId(any())).thenReturn("1");
-            when(jwtUtil.extractUserRole(any())).thenReturn("MANAGER");
+            stubValidToken();
 
             MockHttpServletRequest request = new MockHttpServletRequest();
             request.addHeader("Authorization", "Bearer valid.token.here");
@@ -198,9 +241,7 @@ public class JwtAuthFilterTest {
 
         @Test
         void validToken_filterChainContinues() throws Exception {
-            when(jwtUtil.isTokenValid(any())).thenReturn(true);
-            when(jwtUtil.extractUserId(any())).thenReturn("1");
-            when(jwtUtil.extractUserRole(any())).thenReturn("MANAGER");
+            stubValidToken();
 
             MockHttpServletRequest request = new MockHttpServletRequest();
             request.addHeader("Authorization", "Bearer valid.token.here");
@@ -214,9 +255,7 @@ public class JwtAuthFilterTest {
 
         @Test
         void validToken_securityContextHolderIsPopulated() throws Exception {
-            when(jwtUtil.isTokenValid(any())).thenReturn(true);
-            when(jwtUtil.extractUserId(any())).thenReturn("1");
-            when(jwtUtil.extractUserRole(any())).thenReturn("MANAGER");
+            stubValidToken();
 
             MockHttpServletRequest request = new MockHttpServletRequest();
             request.addHeader("Authorization", "Bearer valid.token.here");
@@ -231,10 +270,8 @@ public class JwtAuthFilterTest {
         }
 
         @Test
-        void validToken_securityContextHolderContainsCorrectUserId() throws Exception {
-            when(jwtUtil.isTokenValid(any())).thenReturn(true);
-            when(jwtUtil.extractUserId(any())).thenReturn("1");
-            when(jwtUtil.extractUserRole(any())).thenReturn("MANAGER");
+        void validToken_principalIsJwtUserPrinciple() throws Exception {
+            stubValidToken();
 
             MockHttpServletRequest request = new MockHttpServletRequest();
             request.addHeader("Authorization", "Bearer valid.token.here");
@@ -244,15 +281,32 @@ public class JwtAuthFilterTest {
             jwtAuthFilter.doFilter(request, response, chain);
 
             Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-            assertEquals("1", auth.getPrincipal(),
-                    "SecurityContextHolder principal should match the user ID extracted from the token");
+            assertInstanceOf(JwtUserPrinciple.class, auth.getPrincipal(),
+                    "Principal should be a JwtUserPrinciple");
+        }
+
+        @Test
+        void validToken_principalContainsCorrectClaims() throws Exception {
+            stubValidToken();
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer valid.token.here");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = mock(FilterChain.class);
+
+            jwtAuthFilter.doFilter(request, response, chain);
+
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            JwtUserPrinciple principal = (JwtUserPrinciple) auth.getPrincipal();
+            assertEquals(1L, principal.userId());
+            assertEquals(7L, principal.orgId());
+            assertEquals("alice", principal.username());
+            assertEquals("MANAGER", principal.role());
         }
 
         @Test
         void validToken_authenticationIsMarkedAsAuthenticated() throws Exception {
-            when(jwtUtil.isTokenValid(any())).thenReturn(true);
-            when(jwtUtil.extractUserId(any())).thenReturn("1");
-            when(jwtUtil.extractUserRole(any())).thenReturn("MANAGER");
+            stubValidToken();
 
             MockHttpServletRequest request = new MockHttpServletRequest();
             request.addHeader("Authorization", "Bearer valid.token.here");
@@ -263,6 +317,23 @@ public class JwtAuthFilterTest {
 
             assertTrue(SecurityContextHolder.getContext().getAuthentication().isAuthenticated(),
                     "Authentication in SecurityContextHolder should be marked as authenticated");
+        }
+
+        @Test
+        void validToken_authorityMatchesRole() throws Exception {
+            stubValidToken();
+
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.addHeader("Authorization", "Bearer valid.token.here");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            FilterChain chain = mock(FilterChain.class);
+
+            jwtAuthFilter.doFilter(request, response, chain);
+
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            assertTrue(auth.getAuthorities().stream()
+                    .anyMatch(a -> a.getAuthority().equals("MANAGER")),
+                    "Authorities should contain the role from the token");
         }
     }
 }

--- a/backend/src/test/java/com/grimni/backend/util/JwtUtilTest.java
+++ b/backend/src/test/java/com/grimni/backend/util/JwtUtilTest.java
@@ -1,5 +1,6 @@
 package com.grimni.backend.util;
 
+import io.jsonwebtoken.JwtException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,15 +22,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class JwtUtilTest {
 
-    // Valid base64 secret that decodes to >= 32 bytes (required for HMAC-SHA256)
-    // Decodes to: "this is a test secret key for unit testing" (43 bytes)
     private static final String TEST_SECRET =
             "dGhpcyBpcyBhIHRlc3Qgc2VjcmV0IGtleSBmb3IgdW5pdCB0ZXN0aW5n";
 
-    /**
-     * Builds a User entity for testing. User.id is set via ReflectionTestUtils
-     * because it's assigned by the DB (GenerationType.IDENTITY) and has no setter.
-     */
     private static User createTestUser(String username, Long userId) {
         User user = new User();
         ReflectionTestUtils.setField(user, "id", userId);
@@ -37,11 +32,6 @@ public class JwtUtilTest {
         return user;
     }
 
-    /**
-     * Builds the OrgUserBridge that represents the user's membership in a specific
-     * organization with a specific role. This is what gets passed to generateToken
-     * alongside the user — the bridge determines the orgId + role claims.
-     */
     private static OrgUserBridge createTestBridge(OrgUserRole role, Long orgId) {
         Organization org = new Organization();
         org.setId(orgId);
@@ -52,9 +42,6 @@ public class JwtUtilTest {
         return bridge;
     }
 
-    // -------------------------------------------------------------------------
-    // Spring context slice — verifies that jwt.secret is loaded from properties
-    // -------------------------------------------------------------------------
     @Nested
     @ExtendWith(SpringExtension.class)
     @Import(JwtUtil.class)
@@ -83,9 +70,6 @@ public class JwtUtilTest {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // Unit tests — no Spring context, secret injected via ReflectionTestUtils
-    // -------------------------------------------------------------------------
     @Nested
     class UnitTests {
 
@@ -161,6 +145,19 @@ public class JwtUtilTest {
             assertFalse(jwtUtil.isTokenValid(""));
         }
 
+        // --- extractAllClaims ------------------------------------------------
+
+        @Test
+        void extractAllClaims_validToken_returnsNonNull() {
+            String token = jwtUtil.generateToken(testUser, testBridge);
+            assertNotNull(jwtUtil.extractAllClaims(token));
+        }
+
+        @Test
+        void extractAllClaims_invalidToken_throwsJwtException() {
+            assertThrows(JwtException.class, () -> jwtUtil.extractAllClaims("invalid.token.string"));
+        }
+
         // --- extractUsername -------------------------------------------------
 
         @Test
@@ -176,33 +173,32 @@ public class JwtUtilTest {
         }
 
         @Test
-        void extractUsername_invalidToken_returnsNull() {
-            assertNull(jwtUtil.extractUsername("invalid.token.string"));
+        void extractUsername_invalidToken_throwsJwtException() {
+            assertThrows(JwtException.class, () -> jwtUtil.extractUsername("invalid.token.string"));
         }
 
         @Test
-        void extractUsername_tokenSignedWithDifferentKey_returnsNull() {
+        void extractUsername_tokenSignedWithDifferentKey_throwsJwtException() {
             JwtUtil otherUtil = new JwtUtil();
             ReflectionTestUtils.setField(otherUtil, "secret",
                     "YW5vdGhlclRlc3RTZWNyZXRLZXlGb3JVbml0VGVzdGluZ09ubHkxMjM=");
             ReflectionTestUtils.invokeMethod(otherUtil, "init");
 
             String foreignToken = otherUtil.generateToken(testUser, testBridge);
-            assertNull(jwtUtil.extractUsername(foreignToken));
+            assertThrows(JwtException.class, () -> jwtUtil.extractUsername(foreignToken));
         }
 
         // --- extractUserId ---------------------------------------------------
-        // sub claim now holds user.getId().toString(), so extractUserId returns a String
 
         @Test
         void extractUserId_validToken_returnsCorrectId() {
             String token = jwtUtil.generateToken(testUser, testBridge);
-            assertEquals("42", jwtUtil.extractUserId(token));
+            assertEquals(42L, jwtUtil.extractUserId(token));
         }
 
         @Test
-        void extractUserId_invalidToken_returnsNull() {
-            assertNull(jwtUtil.extractUserId("invalid.token.string"));
+        void extractUserId_invalidToken_throwsJwtException() {
+            assertThrows(JwtException.class, () -> jwtUtil.extractUserId("invalid.token.string"));
         }
 
         // --- extractUserRole -------------------------------------------------
@@ -222,8 +218,8 @@ public class JwtUtilTest {
         }
 
         @Test
-        void extractUserRole_invalidToken_returnsNull() {
-            assertNull(jwtUtil.extractUserRole("invalid.token.string"));
+        void extractUserRole_invalidToken_throwsJwtException() {
+            assertThrows(JwtException.class, () -> jwtUtil.extractUserRole("invalid.token.string"));
         }
 
         // --- extractUserOrgId ------------------------------------------------
@@ -235,8 +231,8 @@ public class JwtUtilTest {
         }
 
         @Test
-        void extractUserOrgId_invalidToken_returnsNull() {
-            assertNull(jwtUtil.extractUserOrgId("invalid.token.string"));
+        void extractUserOrgId_invalidToken_throwsJwtException() {
+            assertThrows(JwtException.class, () -> jwtUtil.extractUserOrgId("invalid.token.string"));
         }
     }
 }


### PR DESCRIPTION
# Changes
## DTO additions:
added DTO classes for handling organization requests, such as:
- CreateOrganizationRequest (handles requests for creating orgs on POST, primitive datatypes)
- UpdateOrganizationRequest (handles requests for updating an orgs information on PATCH, wrapper types used for not overriding existing data
- OrganizationResponse (creates a fitting object for responding with only necessary data of an organization)


## Organization Controller and Service class
- Added controller class for handling Organization endpoints
- Added service class for the Organization Controller to use

## Tests
- Added tests for Organization controller and service


## Refactoring changes
- JwtUserPrincipal class for creating an object fitting to be wrapped in an Authentication object and set in securityContextHolder
- endpints use PreAuthorize for checking roles upon endpoints for users
- GlobalExceptionHandler for returning less verbose messages upon exceptions

